### PR TITLE
Record videos using Selenium's screenshot feature

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,6 +17,7 @@
         <webtests.findr.verbose>true</webtests.findr.verbose>
         <webtests.video.enabled>true</webtests.video.enabled>
         <webtests.video.failures.only>true</webtests.video.failures.only>
+        <webtests.video.use.selenium>false</webtests.video.use.selenium>
     </properties>
     <repositories>
         <repository>
@@ -61,6 +62,7 @@
                         <webtests.video.enabled>${webtests.video.enabled}</webtests.video.enabled>
                         <webtests.video.dir>${project.build.directory}/webtests-videos</webtests.video.dir>
                         <webtests.video.failures.only>${webtests.video.failures.only}</webtests.video.failures.only>
+                        <webtests.video.use.selenium>${webtests.video.use.selenium}</webtests.video.use.selenium>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/core/src/main/java/com/pojosontheweb/selenium/ScreenRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/ScreenRecordr.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 /**
  * Records the screen to a .mov file.
  */
-public class ScreenRecordr {
+public class ScreenRecordr implements VideoRecordr {
     private String videoUuid = null;
 
     private VideoRecorderConfiguration recorderConfiguration = new VideoRecorderConfiguration();
@@ -44,11 +44,16 @@ public class ScreenRecordr {
         if (recorder == null) {
             return;
         }
-        if (videoUuid==null) {
+        if (videoUuid == null) {
             return;
         }
         String videoPath = recorder.stop();
         Findr.logDebug("[ScreenRecordr] stopped video recording. Video path = " + videoPath);
+    }
+
+    @Override
+    public String getVideoFileExt() {
+        return ".mov";
     }
 
     public List<File> getVideoFiles() {
@@ -65,7 +70,7 @@ public class ScreenRecordr {
         Findr.logDebug("[ScreenRecordr] moving " + files.size() + " video files to " + destDir +
                 " with filePrefix=" + filePrefix);
         int totalCount = 1;
-        boolean needsCount = files.size()>1;
+        boolean needsCount = files.size() > 1;
         for (File f : files) {
             if (f.exists()) {
                 String fileName = filePrefix;
@@ -80,7 +85,7 @@ public class ScreenRecordr {
                 try {
                     Files.copy(f, vidFile);
                     Findr.logDebug("[ScreenRecordr] " + f.getAbsolutePath() + " => " + vidFile.getAbsolutePath());
-                } catch(IOException e) {
+                } catch (IOException e) {
                     throw new RuntimeException(e);
                 } finally {
                     f.delete();
@@ -89,7 +94,6 @@ public class ScreenRecordr {
         }
         return this;
     }
-
 
     public ScreenRecordr removeVideoFiles() {
         Findr.logDebug("[ScreenRecordr] removing video files");

--- a/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
@@ -109,7 +109,7 @@ public class SeleniumRecordr implements VideoRecordr {
         var frameRate = 100 / captureInterval;
         var pattern = pngs.get(0).toPath().resolveSibling(CAPTURE_PATTERN);
         var args = List.of("ffmpeg",
-                // "-hide_banner", "-loglevel", "error",
+                "-hide_banner", "-loglevel", "error",
                 "-f", "image2", "-r", "" + frameRate,
                 "-i", pattern.toString(),
                 "-vcodec", "libx264", "-crf", "22", "-y", path.toString());

--- a/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
@@ -1,0 +1,130 @@
+package com.pojosontheweb.selenium;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.Vector;
+
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+
+public class SeleniumRecordr implements VideoRecordr {
+
+    private static final String CAPTURE_PATTERN = "capture-%05d.png";
+
+    private final TakesScreenshot takesScreenshot;
+    private final int captureInterval = 10; // millis
+    private final List<File> videos = new Vector<>();
+
+    public SeleniumRecordr(TakesScreenshot takesScreenshot) {
+        this.takesScreenshot = takesScreenshot;
+    }
+
+    private Path videoDir = null;
+    private final List<File> pngs = new Vector<>();
+    private Thread recordingThread = null;
+
+    @Override
+    public SeleniumRecordr start() {
+        if (recordingThread != null) {
+            stop();
+        }
+        if (recordingThread == null) {
+            videos.clear();
+            pngs.clear();
+            recordingThread = createRecordingThread();
+            recordingThread.start();
+        }
+        return this;
+    }
+
+    @Override
+    public void stop() {
+        if (recordingThread != null) {
+            if (recordingThread.isAlive()) {
+                while (pngs.isEmpty()) {
+                    try {
+                        Thread.sleep(captureInterval);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+                recordingThread.interrupt();
+            }
+            var vid = createVideo();
+            videos.add(vid);
+            pngs.forEach(File::delete);
+        }
+    }
+
+    @Override
+    public String getVideoFileExt() {
+        return ".mp4";
+    }
+
+    @Override
+    public List<File> getVideoFiles() {
+        return List.copyOf(videos);
+    }
+
+    private Thread createRecordingThread() {
+        return new Thread() {
+            @Override
+            public void run() {
+                try {
+                    do {
+                        File tmp = takesScreenshot.getScreenshotAs(OutputType.FILE);
+                        var pngPath = tmp.toPath().resolveSibling(String.format(CAPTURE_PATTERN, pngs.size()));
+                        var png = Files.move(tmp.toPath(), pngPath);
+                        png.toFile().deleteOnExit();
+                        pngs.add(png.toFile());
+                        Thread.sleep(captureInterval);
+                    } while (recordingThread != null);
+                } catch (InterruptedException ignore) {
+                } catch (Exception e) {
+                    e.getStackTrace();
+                } finally {
+                }
+                recordingThread = null;
+            }
+        };
+    }
+
+    private File createVideo() {
+        if (videoDir == null) {
+            try {
+                videoDir = Files.createTempDirectory("SeleniumRecordr");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        var uuid = UUID.randomUUID();
+        var path = videoDir.resolve(uuid.toString() + getVideoFileExt());
+
+        // TODO
+        // var frameRate = 1000 / captureInterval;
+        var frameRate = 100 / captureInterval;
+        var pattern = pngs.get(0).toPath().resolveSibling(CAPTURE_PATTERN);
+        var args = List.of("ffmpeg",
+                // "-hide_banner", "-loglevel", "error",
+                "-f", "image2", "-r", "" + frameRate,
+                "-i", pattern.toString(),
+                "-vcodec", "libx264", "-crf", "22", "-y", path.toString());
+        System.err.println("FW " + args);
+        try {
+            var p = new ProcessBuilder().redirectErrorStream(true).inheritIO().command(args).start();
+            int status = p.waitFor();
+            if (status != 0) {
+                throw new RuntimeException("ffmpeg failed " + status);
+            }
+        } catch (InterruptedException | IOException e) {
+            // e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+
+        return path.toFile();
+    }
+}

--- a/core/src/main/java/com/pojosontheweb/selenium/VideoRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/VideoRecordr.java
@@ -1,0 +1,60 @@
+package com.pojosontheweb.selenium;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.io.Files;
+
+public interface VideoRecordr {
+
+    VideoRecordr start();
+
+    void stop();
+
+    List<File> getVideoFiles();
+
+    String getVideoFileExt();
+
+    default VideoRecordr moveVideoFilesTo(File destDir, String filePrefix) {
+        stop();
+        List<File> files = getVideoFiles();
+        Findr.logDebug("[ScreenRecordr] moving " + files.size() + " video files to " + destDir +
+                " with filePrefix=" + filePrefix);
+        int totalCount = 1;
+        boolean needsCount = files.size() > 1;
+        for (File f : files) {
+            if (f.exists()) {
+                String fileName = filePrefix;
+                if (needsCount) {
+                    fileName += "-" + totalCount++;
+                }
+                fileName += getVideoFileExt();
+                if (!destDir.exists()) {
+                    destDir.mkdirs();
+                }
+                File vidFile = new File(destDir, fileName);
+                try {
+                    Files.copy(f, vidFile);
+                    Findr.logDebug("[ScreenRecordr] " + f.getAbsolutePath() + " => " + vidFile.getAbsolutePath());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    f.delete();
+                }
+            }
+        }
+        return this;
+    }
+
+    default VideoRecordr removeVideoFiles() {
+        Findr.logDebug("[ScreenRecordr] removing video files");
+        stop();
+        List<File> files = getVideoFiles();
+        for (File f : files) {
+            f.delete();
+        }
+        return this;
+    }
+
+}


### PR DESCRIPTION
Use Seleniums `TakesScreenshot` to capture images, and rely on `ffmpeg` to create an `.mp4` video from those PNG images.

This mode can be activated using property `webtests.video.use.selenium`.

Note, this is the second attempt.
The first attempt was trying to open `com.github.agomezmoron.multimedia.recorder.VideoRecorder` to use Selenium screenshot images, but keep the creation of the video as it.
That failed, because there is no way to run `JpegImagesToMovie` headless, that would require a `xvfb` to run even with headless Chrome/Firefox.

Also note, on the longer term, the new `SeleniumRecordr` could replace the AWT-based tool.