### PR TITLE
increase capture delay, max 5fps

### DIFF
--- a/core/src/main/java/com/pojosontheweb/selenium/ScreenRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/ScreenRecordr.java
@@ -22,6 +22,11 @@ public class ScreenRecordr extends VideoRecordr {
         Findr.logDebug("[ScreenRecordr] screen recorder created");
     }
 
+    @Override
+    protected void setCaptureDelay(int captureDelay) {
+        this.recorderConfiguration.setCaptureInterval(captureDelay);
+    }
+
     public void setRecorderConfiguration(VideoRecorderConfiguration recorderConfiguration) {
         this.recorderConfiguration = recorderConfiguration;
     }

--- a/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
@@ -16,11 +16,16 @@ public class SeleniumRecordr extends VideoRecordr {
     private static final String CAPTURE_PATTERN = "capture-%05d.png";
 
     private final TakesScreenshot takesScreenshot;
-    private final int captureDelay = 250; // millis
+    private int captureDelay = 250; // millis
     private final List<File> videos = new Vector<>();
 
     public SeleniumRecordr(TakesScreenshot takesScreenshot) {
         this.takesScreenshot = takesScreenshot;
+    }
+
+    @Override
+    protected void setCaptureDelay(int captureDelay) {
+        this.captureDelay = captureDelay;
     }
 
     private Path videoTmpDir = null;

--- a/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/SeleniumRecordr.java
@@ -16,7 +16,7 @@ public class SeleniumRecordr extends VideoRecordr {
     private static final String CAPTURE_PATTERN = "capture-%05d.png";
 
     private final TakesScreenshot takesScreenshot;
-    private final int captureInterval = 10; // millis
+    private final int captureDelay = 250; // millis
     private final List<File> videos = new Vector<>();
 
     public SeleniumRecordr(TakesScreenshot takesScreenshot) {
@@ -49,7 +49,7 @@ public class SeleniumRecordr extends VideoRecordr {
             if (recordingThread.isAlive()) {
                 while (pngs.isEmpty()) {
                     try {
-                        Thread.sleep(captureInterval);
+                        Thread.sleep(captureDelay);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -92,7 +92,7 @@ public class SeleniumRecordr extends VideoRecordr {
                         var png = Files.move(tmp.toPath(), pngPath);
                         png.toFile().deleteOnExit();
                         pngs.add(png.toFile());
-                        Thread.sleep(captureInterval);
+                        Thread.sleep(captureDelay);
                     } while (recordingThread != null);
                 } catch (InterruptedException ignore) {
                 } catch (Exception e) {
@@ -107,7 +107,7 @@ public class SeleniumRecordr extends VideoRecordr {
         var path = videoTmpDir.resolve(uuid.toString() + getVideoFileExt());
 
         var frameRate = durationMillis > 0 ? (pngs.size() / (durationMillis / 1000))
-                : (1000 / captureInterval);
+                : (1000 / captureDelay);
         var pattern = videoTmpDir.resolve(CAPTURE_PATTERN);
         var args = List.of("ffmpeg",
                 "-hide_banner", "-loglevel", "error",

--- a/core/src/main/java/com/pojosontheweb/selenium/TestUtil.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/TestUtil.java
@@ -1,9 +1,9 @@
 package com.pojosontheweb.selenium;
 
+import java.io.File;
+
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
-
-import java.io.File;
 
 /**
  * Helper for test cases. Maps on the lifecycle of a typical test case
@@ -18,6 +18,7 @@ public class TestUtil {
     public static final String SYS_PROP_VIDEO_FAILED_ONLY = "webtests.video.failures.only";
     public static final String SYS_PROP_VIDEO_DIR = "webtests.video.dir";
     public static final String SYS_PROP_VIDEO_USE_SELENIUM = "webtests.video.use.selenium";
+    public static final String SYS_PROP_VIDEO_CAPTURE_DELAY = "webtests.video.capture.delay";
 
     private WebDriver webDriver;
     private boolean videoEnabled = isVideoEnabledFromSysProps();
@@ -43,6 +44,18 @@ public class TestUtil {
     protected static boolean isVideoUseSelenium() {
         String prop = System.getProperty(SYS_PROP_VIDEO_USE_SELENIUM, "false");
         return "true".equals(prop.toLowerCase());
+    }
+
+    protected static Integer getVideoCaptureDelayMillis() {
+        String prop = System.getProperty(SYS_PROP_VIDEO_CAPTURE_DELAY, null);
+        if (prop != null) {
+            try {
+                return Integer.parseInt(prop);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
     }
 
     public boolean isVideoEnabled() {
@@ -112,8 +125,12 @@ public class TestUtil {
             } else {
                 log("video is enabled, starting recorder");
                 recordr = new ScreenRecordr();
-                recordr.start();
             }
+            var captureDelay = getVideoCaptureDelayMillis();
+            if (captureDelay != null) {
+                recordr.setCaptureDelay(captureDelay);
+            }
+            recordr.start();
         }
     }
 

--- a/core/src/main/java/com/pojosontheweb/selenium/VideoRecordr.java
+++ b/core/src/main/java/com/pojosontheweb/selenium/VideoRecordr.java
@@ -8,6 +8,8 @@ import com.google.common.io.Files;
 
 public abstract class VideoRecordr {
 
+    protected abstract void setCaptureDelay(int captureDelay);
+
     public abstract VideoRecordr start();
 
     protected abstract void stop(boolean createVideo);


### PR DESCRIPTION
Video capture delay is configurable, via system property `webtests.video.capture.delay`, in milliseconds.